### PR TITLE
latest updates fix kernel panic

### DIFF
--- a/driver/bypass.h
+++ b/driver/bypass.h
@@ -226,11 +226,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define WDT_STATUS_DIS 0
 
 struct softc_ex {
-#if __FreeBSD_version < 600000
-    struct arpcom   interface_data;
-#else
     struct ifnet   *ifp;
-#endif
 };
 
 struct bpctl_osdep {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,11 @@ I've downloaded this driver from from https://www.silicom-usa.com/drivercat/bypa
 on May 31, 2022, Version 4.0.2 09/03/2021 (zip file on ftp dated Oct 19, 2021)
 
 And changed it to update the timeout/untimeout calls to callout(9) as
-timeout was removed from FreeBSD 13.0 and later.
+timeout was removed from FreeBSD 13.0 and later. Interface scanning on each
+ioctl was removed; it was panicing on my hosts, so I switched the load time
+interface scanning to use ifunit_ref, added in FreeBSD 8, which I think may
+better handle the reasoning behind if_scan? Additionally, ifdefs allowing
+compilation on kernels earlier than FreeBSD 6 was removed.
 
 As a side-note, if you've got a PEG4BPI or similar, older card that shows up
 with vendor=0x1374, and not just the subvendor set; it might be possible to

--- a/readme.txt
+++ b/readme.txt
@@ -7,13 +7,13 @@ And changed it to update the timeout/untimeout calls to callout(9) as
 timeout was removed from FreeBSD 13.0 and later.
 
 As a side-note, if you've got a PEG4BPI or similar, older card that shows up
-with vendor=0x1374 device=0x0038 (or similar); it might be possible to
+with vendor=0x1374, and not just the subvendor set; it might be possible to
 adjust the eeprom to show up with Intel vendor and device ids, and then
 it'll be much easier to use.  The simplest way I found to do that is not
 super simple, but install the card in a system that can do IO-MMU based PCI
 passthrough to a VM; run a Linux vm, with the NIC(s) passed through with the
 expected Intel vendor and device id, and then you should be able to use
-ethtool to adjust the EEPROM. For my PEG4BPI, the desired vendor is 0x8086,
+ethtool to adjust the EEPROM.  For my PEG4BPI, the desired vendor is 0x8086,
 device 0x105E, and Initialization Control Word 1 (Word 0Ah) needed to be
 adjusted, ethtool shows that word as offset 0x14 (low byte) and 0x15 (high
 byte); bit zero of the low byte controls whether the device uses the default

--- a/util/bpctl_util.c
+++ b/util/bpctl_util.c
@@ -1157,7 +1157,7 @@ void get_bypass_caps_cmd(int file_desc,int if_index, int bus, int slot, int func
     }
     for (i=0;bp_cap_array[i].flag;i++) {
         if (bpctl_cmd.status & bp_cap_array[i].flag)
-            printf(bp_cap_array[i].desc);
+            printf("%s", bp_cap_array[i].desc);
     }
 }
 


### PR DESCRIPTION
Just FYI, if you're using this, you probably want to pick up at least the commit 8674826; this fixes a kernel panic if you run any bpctl command with a specific nic; ex: ```bpctl_util ix0 get_bypass``` would kernel panic if ix0 was a silicom nic, at least in my testing.

Hope this helps.